### PR TITLE
refactor: docker healthcheck to be more permissive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ COPY --from=build-env --chown=nonroot:nonroot /go/bin/app /
 USER nonroot
 
 # Using custom health checker
-HEALTHCHECK --interval=10s --timeout=1s \
+HEALTHCHECK --interval=10s --timeout=5s --retries=2\
   CMD ["/healthchecker"]
 
 # Run app


### PR DESCRIPTION
With the default Healthcheck, the timeout is set to strict. When using
the bouncer on a node with a high load, the container runs fine but the
healthcheck is not finished within 1s thus killing the container. By
setting the healthcheck to a larger timeout and include some retries,
the healthcheck should work fine even when executed on high load nodes.