### PR TITLE
Fix for Trusted Proxies and use ClientID()

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The webservice configuration is made via environment variables:
 * `CROWDSEC_BOUNCER_LOG_LEVEL`          - Minimum log level for bouncer. Expected value [zerolog levels](https://pkg.go.dev/github.com/rs/zerolog#readme-leveled-logging). Default to 1
 * `PORT`                                - Change listening port of web server. Default listen on 8080
 * `GIN_MODE`                            - By default, run app in "debug" mode. Set it to "release" in production
+* `TRUSTED_PROXIES`                     - Can accept a list of IP addresses in CIDR format, delimited by ','. Default is 0.0.0.0/0
 
 ## Exposed routes
 The webservice exposes some routes:

--- a/bouncer.go
+++ b/bouncer.go
@@ -9,9 +9,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	"strings"
 )
 
 var logLevel = OptionalEnv("CROWDSEC_BOUNCER_LOG_LEVEL", "1")
+var trustedProxiesList = strings.Split(OptionalEnv("TRUSTED_PROXIES", "0.0.0.0/0"), ",")
 
 func main() {
 	router, err := setupRouter()
@@ -48,7 +50,7 @@ func setupRouter() (*gin.Engine, error) {
 
 	// Web framework
 	router := gin.New()
-	err = router.SetTrustedProxies(nil)
+	err = router.SetTrustedProxies(trustedProxiesList)
 	if err != nil {
 		return nil, err
 	}

--- a/controler/controler.go
+++ b/controler/controler.go
@@ -108,12 +108,13 @@ func isIpAuthorized(realIP string) (bool, error) {
 func ForwardAuth(c *gin.Context) {
 	ipProcessed.Inc()
 	log.Debug().
+		Str("ClientIP", c.ClientIP()).
 		Str(forwardHeader, c.Request.Header.Get(forwardHeader)).
 		Str(clientIpHeader, c.Request.Header.Get(clientIpHeader)).
 		Msg("Handling forwardAuth request")
 
-	// Getting and verifying ip from header
-	isAuthorized, err := isIpAuthorized(c.Request.Header.Get(clientIpHeader))
+	// Getting and verifying ip using ClientIP function
+	isAuthorized, err := isIpAuthorized(c.ClientIP())
 	if err != nil {
 		log.Warn().Err(err).Msgf("An error occurred while checking IP %q", c.Request.Header.Get(clientIpHeader))
 		c.String(http.StatusForbidden, "Forbidden")


### PR DESCRIPTION
Not sure if you accept pull requests so here goes? This is related to  #10 

Sets this to work correctly on ClientID() which defaults to X-Forwarded-For behind a trusted proxy.
Since this should be behind traefik and traefik decides which proxies it trusts before we can keep this set as 0.0.0.0/0 but there is an option to set this with the TRUSTED_PROXIES environmental variable.

Note that this might not be as performant as setting SetTrustedProxy(nil) and using ClientID() if you don't have proxies before Traefik. I wanted to add in some logic to set SetTrustedProxy(nil) instead if TRUSTED_PROXY wasn't set at all but my experience with go isn't that great and honestly not sure it even matters in most use cases for this bouncer but it is a potential for improvement if you want the previous functionality to stand.