### PR TITLE
Added support for docker secrets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ func OptionalEnv(varName string, optional string) string {
 }
 
 /*
-	Check for an environment variable value or the equivalent docker secret, exit program if not found
+	Check for an environment variable value or the value of a file, exit program if not found
 */
 func RequiredEnv(varName string) string {
 	envVar := os.Getenv(varName)

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ func RequiredEnv(varName string) string {
 	} else if envVar == "" && envVarFileName != "" {
 		envVarFromFile, err := os.ReadFile(envVarFileName)
 		if err != nil {
-			log.Fatalf("Could not read env var from file %s. Exiting", envVarFileName)
+			log.Fatalf("Could not read env var from file %s (Error: %v). Exiting", envVarFileName, err)
 		}
 		return string(envVarFromFile)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -18,12 +18,19 @@ func OptionalEnv(varName string, optional string) string {
 }
 
 /*
-	Check for an environment variable value, exit program if not found
+	Check for an environment variable value or the equivalent docker secret, exit program if not found
 */
 func RequiredEnv(varName string) string {
 	envVar := os.Getenv(varName)
-	if envVar == "" {
+	envVarFileName := os.Getenv(varName + "_FILE")
+	if envVar == "" && envVarFileName == "" {
 		log.Fatalf("The required env var %s is not provided. Exiting", varName)
+	} else if envVar == "" && envVarFileName != "" {
+		envVarFromFile, err := os.ReadFile(envVarFileName)
+		if err != nil {
+			log.Fatalf("Could not read env var from file %s. Exiting", envVarFileName)
+		}
+		return string(envVarFromFile)
 	}
 	return envVar
 }


### PR DESCRIPTION
Right now the bouncer API key needs to be hardcoded in the compose file and/or in the external `.env`. The current best practice is to leverage [docker secrets](https://docs.docker.com/engine/swarm/secrets/#defining-and-using-secrets-in-compose-files) that are not only supported in swarm mode, but also from docker compose.

I have added a basic implementation within the `RequiredEnv` function, that allows the use of `<environment_variable_name>+_FILE` instead of `<environment_variable_name>`. So `CROWDSEC_BOUNCER_API_KEY` becomes `CROWDSEC_BOUNCER_API_KEY_FILE`. If said `[...]_FILE` variable exists the value is read from the file and returned from the `RequiredEnv` function.

I'd greatly appreciate some testing since logging from `config.go` seems kind of impossible? Even the existing `log.Fatalf()` entries I never get to see in the docker logs (though the container doesn't start).

Example docker-compose:
```yml
version: "3.8"

secrets:
  crowdsec_bouncer_api_key:
    file: /secretsPath/crowdsec_bouncer_api_key

services:
  bouncer:
    build: .
    image: fbonalair/traefik-crowdsec-bouncer
    container_name: bouncer
    environment:
      CROWDSEC_BOUNCER_API_KEY_FILE: /run/secrets/crowdsec_bouncer_api_key
      CROWDSEC_AGENT_HOST: crowdsec:8123
    secrets:
      - crowdsec_bouncer_api_key
```