### PR TITLE
Add support for skipping TLS certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,17 @@ Generate a bouncer API key following [CrowdSec documentation](https://doc.crowds
 ## Configuration
 The webservice configuration is made via environment variables:
 
-* `CROWDSEC_BOUNCER_API_KEY`            - CrowdSec bouncer API key required to be authorized to request local API (required)`
-* `CROWDSEC_AGENT_HOST`                 - Host and port of CrowdSec agent, i.e. crowdsec-agent:8080 (required)`
-* `CROWDSEC_BOUNCER_SCHEME`             - Scheme to query CrowdSec agent. Expected value: http, https. Default to http`
-* `CROWDSEC_BOUNCER_LOG_LEVEL`          - Minimum log level for bouncer. Expected value [zerolog levels](https://pkg.go.dev/github.com/rs/zerolog#readme-leveled-logging). Default to 1
-* `CROWDSEC_BOUNCER_BAN_RESPONSE_CODE`  - HTTP code to respond in case of ban. Default to 403
-* `CROWDSEC_BOUNCER_BAN_RESPONSE_MSG`   - HTTP body as message to respond in case of ban. Default to Forbidden
-* `HEALTH_CHECKER_TIMEOUT_DURATION`     - [Golang string represation of a duration](https://pkg.go.dev/time#ParseDuration) to wait for bouncer's answer before failing health check. Default to 2s
-* `PORT`                                - Change listening port of web server. Default listen on 8080
-* `GIN_MODE`                            - By default, run app in "debug" mode. Set it to "release" in production
-* `TRUSTED_PROXIES`                     - List of trusted proxies IP addresses in CIDR format, delimited by ','. Default of 0.0.0.0/0 should be fine for most use cases, but you HAVE to add them directly in Traefik. 
+* `CROWDSEC_BOUNCER_API_KEY`              - CrowdSec bouncer API key required to be authorized to request local API (required)`
+* `CROWDSEC_AGENT_HOST`                   - Host and port of CrowdSec agent, i.e. crowdsec-agent:8080 (required)`
+* `CROWDSEC_BOUNCER_SCHEME`               - Scheme to query CrowdSec agent. Expected value: http, https. Default to http`
+* `CROWDSEC_BOUNCER_LOG_LEVEL`            - Minimum log level for bouncer. Expected value [zerolog levels](https://pkg.go.dev/github.com/rs/zerolog#readme-leveled-logging). Default to 1
+* `CROWDSEC_BOUNCER_BAN_RESPONSE_CODE`    - HTTP code to respond in case of ban. Default to 403
+* `CROWDSEC_BOUNCER_BAN_RESPONSE_MSG`     - HTTP body as message to respond in case of ban. Default to Forbidden
+* `CROWDSEC_BOUNCER_INSECURE_SKIP_VERIFY` - Skip TLS certificate verification. Set to `true` to activate. Default: `false`
+* `HEALTH_CHECKER_TIMEOUT_DURATION`       - [Golang string represation of a duration](https://pkg.go.dev/time#ParseDuration) to wait for bouncer's answer before failing health check. Default to 2s
+* `PORT`                                  - Change listening port of web server. Default listen on 8080
+* `GIN_MODE`                              - By default, run app in "debug" mode. Set it to "release" in production
+* `TRUSTED_PROXIES`                       - List of trusted proxies IP addresses in CIDR format, delimited by ','. Default of 0.0.0.0/0 should be fine for most use cases, but you HAVE to add them directly in Traefik. 
 
 ## Exposed routes
 The webservice exposes some routes:

--- a/controler/controler.go
+++ b/controler/controler.go
@@ -2,6 +2,7 @@ package controler
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,6 +32,7 @@ const (
 var crowdsecBouncerApiKey = RequiredEnv("CROWDSEC_BOUNCER_API_KEY")
 var crowdsecBouncerHost = RequiredEnv("CROWDSEC_AGENT_HOST")
 var crowdsecBouncerScheme = OptionalEnv("CROWDSEC_BOUNCER_SCHEME", "http")
+var crowdsecBouncerInsecureSkipVerify, err = strconv.ParseBool(OptionalEnv("CROWDSEC_BOUNCER_INSECURE_SKIP_VERIFY", "false"))
 var crowdsecBanResponseCode, _ = strconv.Atoi(OptionalEnv("CROWDSEC_BOUNCER_BAN_RESPONSE_CODE", "403")) // Validated via ValidateEnv()
 var crowdsecBanResponseMsg = OptionalEnv("CROWDSEC_BOUNCER_BAN_RESPONSE_MSG", "Forbidden")
 var (
@@ -44,6 +46,7 @@ var client = &http.Client{
 	Transport: &http.Transport{
 		MaxIdleConns:    10,
 		IdleConnTimeout: 30 * time.Second,
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: crowdsecBouncerInsecureSkipVerify},
 	},
 	Timeout: 5 * time.Second,
 }


### PR DESCRIPTION
[CrowdSec](https://github.com/crowdsecurity/crowdsec) now allows automatic agent registration if mutual-TLS is activated on the LAPI server/instance.  This will probably be the most common way Kubernetes deployments of CrowdSec will operate.

However, when TLS mode is activated on the LAPI server, most of the time it will be using self-signed certificates.  In this Traefik CrowdSec bouncer, it's possible to change the scheme from `http` to `https`, but certificate verification will fail with self-signed certificates.  This PR adds an environment variable to allow one to deactivate certificate verification.